### PR TITLE
chore: repo hardening round 2 (Dependabot config)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds a Dependabot configuration (.github/dependabot.yml) enabling weekly dependency update checks for the pip ecosystem (requirements.txt) and GitHub Actions (.github/workflows). This change is purely additive and non-breaking: it only introduces a new file and does not modify any existing files or behavior.